### PR TITLE
Fix preference typing DRYness and target-date action label

### DIFF
--- a/src/clock.ts
+++ b/src/clock.ts
@@ -1,8 +1,8 @@
-import { getPreferenceValues } from "@raycast/api";
+import { getAppPreferences } from "./preferences";
 
 export type ClockFormat = "12h" | "24h";
 
 export function getClockFormat(): ClockFormat {
-  const prefs = getPreferenceValues<{ clockFormat?: ClockFormat }>();
+  const prefs = getAppPreferences();
   return (prefs.clockFormat as ClockFormat) ?? "24h";
 }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,0 +1,13 @@
+import { getPreferenceValues } from "@raycast/api";
+
+export type AppPreferences = {
+  units?: "metric" | "imperial";
+  showWindDirection?: boolean;
+  showSunTimes?: boolean;
+  clockFormat?: "12h" | "24h";
+  debugMode?: boolean;
+};
+
+export function getAppPreferences(): AppPreferences {
+  return getPreferenceValues<AppPreferences>();
+}

--- a/src/units.ts
+++ b/src/units.ts
@@ -1,15 +1,15 @@
-import { getPreferenceValues } from "@raycast/api";
 import { convertTemperature, convertSpeed, convertPrecipitation } from "./config/weather-config";
+import { getAppPreferences } from "./preferences";
 
 export type Units = "metric" | "imperial";
 
 export function getUnits(): Units {
-  const prefs = getPreferenceValues<{ units?: Units }>();
+  const prefs = getAppPreferences();
   return (prefs.units as Units) ?? "metric";
 }
 
 export function getFeatureFlags(): { showWindDirection: boolean; showSunTimes: boolean } {
-  const prefs = getPreferenceValues<{ showWindDirection?: boolean; showSunTimes?: boolean }>();
+  const prefs = getAppPreferences();
   return {
     showWindDirection: prefs.showWindDirection ?? true,
     showSunTimes: prefs.showSunTimes ?? true,

--- a/src/utils/debug-utils.ts
+++ b/src/utils/debug-utils.ts
@@ -1,14 +1,10 @@
-import { getPreferenceValues } from "@raycast/api";
-
-type DebugPreferences = {
-  debugMode?: boolean;
-};
+import { getAppPreferences } from "../preferences";
 
 // Evaluated once at module load. Raycast extensions are short-lived processes,
 // so a preference change takes effect on the next launch — which is acceptable.
 const DEBUG_ENABLED = (() => {
   try {
-    return getPreferenceValues<DebugPreferences>().debugMode === true;
+    return getAppPreferences().debugMode === true;
   } catch {
     return false;
   }

--- a/src/utils/location-utils.tsx
+++ b/src/utils/location-utils.tsx
@@ -46,7 +46,7 @@ export class LocationUtils {
         {targetDate && (
           <>
             <Action.Push
-              title="View Tomorrow's Weather"
+              title={`View ${targetDate.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })} Weather`}
               icon={Icon.Clock}
               target={
                 <LazyForecastView


### PR DESCRIPTION
## Summary
- centralize extension preference typing in a shared `AppPreferences` helper and use it from clock, units, and debug utilities to remove repeated inline generics
- update the date-specific action in location actions to show the actual formatted `targetDate` instead of a hardcoded "Tomorrow" label
- preserve existing fallback behavior (`24h`, `metric`, and feature flag defaults) while reducing maintenance risk from duplicated preference typings

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run format-check`
- [x] `npm run build`
- [x] `npm run test:unit`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes preference access while preserving existing defaults; only user-facing change is an action title string for date-specific forecasts.
> 
> **Overview**
> Centralizes Raycast preference typing/access into a new `getAppPreferences()` helper (`AppPreferences`) and updates `clock`, `units` (including feature flags), and `DebugLogger` to consume it instead of repeating inline `getPreferenceValues` generics.
> 
> Updates the date-specific forecast action title in `location-utils.tsx` to render the actual formatted `targetDate` rather than a hardcoded “Tomorrow” label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d63ab54d5eb84fc3c3462edb87b827fb858128f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->