### PR TITLE
ci: move workflow actions to Node 24-compatible runtime

### DIFF
--- a/.github/workflows/raycast-ci.yml
+++ b/.github/workflows/raycast-ci.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 15
     env:
+      # Opt in now to GitHub's Node 24 JavaScript action runtime.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       NODE_VERSION: "22"
       # Keep npm cache inside the workspace (avoids permission issues).
       NPM_CONFIG_CACHE: .npm-cache
@@ -23,17 +25,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.NPM_CONFIG_CACHE }}
           key: ${{ runner.os }}-npm-cache-node${{ env.NODE_VERSION }}-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Summary
- Brings `.github/workflows/raycast-ci.yml` onto GitHub's Node 24-compatible JavaScript action runtime path.
- Upgrades `actions/checkout`, `actions/setup-node`, and `actions/cache` from `@v4` to `@v5`.
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: \"true\"` to proactively avoid action-runtime deprecation churn.

## Test plan
- [x] Verified branch diff against `main` only changes `.github/workflows/raycast-ci.yml`
- [x] Verified commit history contains a single atomic commit for this change
- [ ] Let GitHub Actions run on this PR and confirm workflow passes end-to-end

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes CI workflow action versions and an environment opt-in flag, with no production code impact. Main risk is CI breakage if the updated action versions behave differently.
> 
> **Overview**
> Updates `.github/workflows/raycast-ci.yml` to opt into GitHub’s Node 24 JavaScript actions runtime via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
> 
> Bumps `actions/checkout`, `actions/setup-node`, and `actions/cache` from `@v4` to `@v5` to stay compatible with the newer runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99607fd28252c408d1301e1c92782cd7ffb3bfba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->