### PR TITLE
fix: deduplicate date forecast actions in date-intent search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Yr Weather Forecast Changelog
 
+## [Date query action bugfix] - 2026-05-13
+
+- Fix duplicated date forecast actions in search results: `Open Forecast` is now the single date-specific entry point, while `View Full Forecast` stays as the explicit fallback.
+
 ## [Reliability, dark mode, and quality overhaul] - {PR_MERGE_DATE}
 
 - Add 12/24-hour clock format preference (defaults to 24h)

--- a/src/utils/location-utils.tsx
+++ b/src/utils/location-utils.tsx
@@ -46,11 +46,7 @@ export class LocationUtils {
             title="View Full Forecast"
             icon={Icon.Calendar}
             target={
-              <LazyForecastView
-                location={location}
-                onShowWelcome={onShowWelcome}
-                onFavoriteChange={onFavoriteChange}
-              />
+              <LazyForecastView location={location} onShowWelcome={onShowWelcome} onFavoriteChange={onFavoriteChange} />
             }
           />
         )}

--- a/src/utils/location-utils.tsx
+++ b/src/utils/location-utils.tsx
@@ -42,19 +42,17 @@ export class LocationUtils {
 
         {/* Date-specific fallback action */}
         {targetDate && (
-          <>
-            <Action.Push
-              title="View Full Forecast"
-              icon={Icon.Calendar}
-              target={
-                <LazyForecastView
-                  location={location}
-                  onShowWelcome={onShowWelcome}
-                  onFavoriteChange={onFavoriteChange}
-                />
-              }
-            />
-          </>
+          <Action.Push
+            title="View Full Forecast"
+            icon={Icon.Calendar}
+            target={
+              <LazyForecastView
+                location={location}
+                onShowWelcome={onShowWelcome}
+                onFavoriteChange={onFavoriteChange}
+              />
+            }
+          />
         )}
 
         <Action

--- a/src/utils/location-utils.tsx
+++ b/src/utils/location-utils.tsx
@@ -40,21 +40,9 @@ export class LocationUtils {
           }
         />
 
-        {/* Date-specific forecast actions - single day view for specific dates */}
+        {/* Date-specific fallback action */}
         {targetDate && (
           <>
-            <Action.Push
-              title={`View ${targetDate.toLocaleDateString(undefined, { weekday: "long", month: "short", day: "numeric" })} Weather`}
-              icon={Icon.Clock}
-              target={
-                <LazyForecastView
-                  location={location}
-                  onShowWelcome={onShowWelcome}
-                  targetDate={toLocalDateString(targetDate)}
-                  onFavoriteChange={onFavoriteChange}
-                />
-              }
-            />
             <Action.Push
               title="View Full Forecast"
               icon={Icon.Calendar}

--- a/tests/__mocks__/@raycast/api.ts
+++ b/tests/__mocks__/@raycast/api.ts
@@ -10,6 +10,20 @@ export const Toast = {
 
 export const showToast = jest.fn(async () => undefined);
 
+type ActionLike = ((props: unknown) => null) & {
+  Push?: (props: unknown) => null;
+};
+
+export const Action: ActionLike = (() => null) as ActionLike;
+Action.Push = () => null;
+
+export const ActionPanel = () => null;
+
+export const Icon = {
+  Clock: "clock",
+  Calendar: "calendar",
+};
+
 export const getPreferenceValues = jest.fn(() => ({
   units: "metric",
   clockFormat: "24h",

--- a/tests/unit/location-utils.test.ts
+++ b/tests/unit/location-utils.test.ts
@@ -125,3 +125,90 @@ describe("LocationUtils.sortLocationsByPrecision with query relevance", () => {
     expect(sorted[0].displayName).toBe("City Match");
   });
 });
+
+describe("LocationUtils.createLocationActions", () => {
+  const sampleLocation: LocationResult = {
+    id: "1",
+    displayName: "Oslo, Norway",
+    lat: 59.9139,
+    lon: 10.7522,
+  };
+
+  function collectActionTitles(node: unknown): string[] {
+    const titles: string[] = [];
+
+    const walk = (value: unknown) => {
+      if (!value) return;
+      if (Array.isArray(value)) {
+        for (const item of value) walk(item);
+        return;
+      }
+      if (typeof value !== "object") return;
+
+      const candidate = value as { props?: Record<string, unknown> };
+      const props = candidate.props;
+      if (!props) return;
+
+      if (typeof props.title === "string") {
+        titles.push(props.title);
+      }
+      walk(props.children);
+    };
+
+    walk(node);
+    return titles;
+  }
+
+  function getOpenForecastTargetDate(node: unknown): string | undefined {
+    const walk = (value: unknown): string | undefined => {
+      if (!value) return undefined;
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          const found = walk(item);
+          if (found) return found;
+        }
+        return undefined;
+      }
+      if (typeof value !== "object") return undefined;
+
+      const candidate = value as {
+        props?: {
+          title?: unknown;
+          target?: { props?: { targetDate?: string } };
+          children?: unknown;
+        };
+      };
+      const props = candidate.props;
+      if (!props) return undefined;
+
+      if (props.title === "Open Forecast") {
+        return props.target?.props?.targetDate;
+      }
+      return walk(props.children);
+    };
+
+    return walk(node);
+  }
+
+  it("shows one default open action for non-date searches", () => {
+    const actions = LocationUtils.createLocationActions(sampleLocation, false, jest.fn());
+    const titles = collectActionTitles(actions);
+
+    expect(titles).toContain("Open Forecast");
+    expect(titles).toContain("Show Current Weather");
+    expect(titles).not.toContain("View Full Forecast");
+    expect(titles.some((title) => /^View .* Weather$/.test(title))).toBe(false);
+    expect(getOpenForecastTargetDate(actions)).toBeUndefined();
+  });
+
+  it("uses Open Forecast as the only date-specific open action", () => {
+    const actions = LocationUtils.createLocationActions(sampleLocation, false, jest.fn(), undefined, new Date("2026-03-08"));
+    const titles = collectActionTitles(actions);
+
+    expect(titles).toContain("Open Forecast");
+    expect(titles).toContain("View Full Forecast");
+    expect(titles).toContain("Show Current Weather");
+    expect(titles.some((title) => /^View .* Weather$/.test(title))).toBe(false);
+    expect(getOpenForecastTargetDate(actions)).toBe("2026-03-08");
+  });
+});

--- a/tests/unit/location-utils.test.ts
+++ b/tests/unit/location-utils.test.ts
@@ -1,4 +1,5 @@
 import type { LocationResult } from "../../src/location-search";
+import { parseLocalDateString } from "../../src/utils/date-utils";
 import { LocationUtils } from "../../src/utils/location-utils";
 
 function location(overrides: Partial<LocationResult>): LocationResult {
@@ -202,7 +203,13 @@ describe("LocationUtils.createLocationActions", () => {
   });
 
   it("uses Open Forecast as the only date-specific open action", () => {
-    const actions = LocationUtils.createLocationActions(sampleLocation, false, jest.fn(), undefined, new Date("2026-03-08"));
+    const actions = LocationUtils.createLocationActions(
+      sampleLocation,
+      false,
+      jest.fn(),
+      undefined,
+      parseLocalDateString("2026-03-08"),
+    );
     const titles = collectActionTitles(actions);
 
     expect(titles).toContain("Open Forecast");


### PR DESCRIPTION
## Summary
- remove the duplicated date-specific action from search result actions so date-intent flows have one canonical open path
- keep `View Full Forecast` when a target date exists, preserving an explicit fallback to non-date forecast mode
- add unit coverage for date and non-date action composition, plus a short changelog note for the bugfix release

## Test plan
- [x] `npm run test:unit -- location-utils.test.ts`
- [x] verify no unstaged/staged changes after commits (`git status`)
- [ ] manual sanity check in Raycast dev mode (date-intent query shows one date-specific open path + `View Full Forecast`)

## Risk
- low: change is localized to search-result action composition in `src/utils/location-utils.tsx`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is localized to Raycast search action composition and adds unit tests to lock in behavior, with no changes to data fetching or storage.
> 
> **Overview**
> Search result actions no longer show a duplicated date-specific forecast entry: `Open Forecast` is now the single date-aware entry point, and `View Full Forecast` is kept only as a fallback when a `targetDate` is present.
> 
> Adds unit coverage for `LocationUtils.createLocationActions` to assert action titles and that `Open Forecast` carries the expected `targetDate` in date-intent queries, and updates the `@raycast/api` test mock to include `Action.Push`/`Icon` used by these actions. Also adds a short changelog entry documenting the bugfix release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b577823fc318702a9a5b9f46c7ac758c40afc13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->